### PR TITLE
fix: 12508 change `invalid_var_arg` error wording

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -944,7 +944,7 @@ class MessageBuilder:
             self.fail('Cannot infer function type argument', context)
 
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
-        self.fail('List or tuple expected as variable arguments', context)
+        self.fail('List or tuple expected as variadic arguments', context)
 
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         typ = get_proper_type(typ)

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -275,7 +275,7 @@ class CC(C): pass
 a = None # type: A
 
 f(*None)
-f(*a)    # E: List or tuple expected as variable arguments
+f(*a)    # E: List or tuple expected as variadic arguments
 f(*(a,))
 
 def f(a: 'A') -> None:
@@ -544,9 +544,9 @@ if int():
 if int():
     b, b = f(b, b, *aa) # E: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
 if int():
-    a, b = f(a, *a)  # E: List or tuple expected as variable arguments
+    a, b = f(a, *a)  # E: List or tuple expected as variadic arguments
 if int():
-    a, b = f(*a)     # E: List or tuple expected as variable arguments
+    a, b = f(*a)     # E: List or tuple expected as variadic arguments
 
 if int():
     a, a = f(*aa)
@@ -758,5 +758,5 @@ bar(*good1)
 bar(*good2)
 bar(*good3)
 bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
-bar(*bad2)  # E: List or tuple expected as variable arguments
+bar(*bad2)  # E: List or tuple expected as variadic arguments
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

"Fixes #12508"

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

We fix the issue within message.py so that it will check the incoming context and produce a different error when encountering variadic arguments. We also modified the tests accordingly. Now, it passes all the tests.
